### PR TITLE
Update rtsx driver for modern kernel API compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,11 +36,11 @@ $(TARGET_MODULE)-objs := rtsx.o rtsx_chip.o rtsx_transport.o rtsx_scsi.o rtsx_ca
 default:
 	sed "s/RTSX_MK_TIME/`date +%y.%m.%d.%H.%M`/" timestamp.in > timestamp.h
 	cp -f ./define.release ./define.h
-	make -C /lib/modules/$(KVERSION)/build/ SUBDIRS=$(PWD) modules
+	make -C /lib/modules/$(KVERSION)/build/ M=$(PWD) modules
 debug:
 	sed "s/RTSX_MK_TIME/`date +%y.%m.%d.%H.%M`/" timestamp.in > timestamp.h
 	cp -f ./define.debug ./define.h
-	make -C /lib/modules/$(KVERSION)/build/ SUBDIRS=$(PWD) modules
+	make -C /lib/modules/$(KVERSION)/build/ M=$(PWD) modules
 install:
 	cp $(TARGET_MODULE).ko /lib/modules/$(KVERSION)/kernel/drivers/scsi -f
 clean:

--- a/rtsx.c
+++ b/rtsx.c
@@ -138,44 +138,34 @@ static int slave_configure(struct scsi_device *sdev)
 #define SPRINTF(args...) \
 	do { if (pos < buffer+length) pos += sprintf(pos, ## args); } while (0)
 
-static int queuecommand_lck(struct scsi_cmnd *srb,
-			void (*done)(struct scsi_cmnd *))
+static int queuecommand_lck(struct scsi_cmnd *srb)
 {
 	struct rtsx_dev *dev = host_to_rtsx(srb->device->host);
 	struct rtsx_chip *chip = dev->chip;
 
-	
+
 	if (chip->srb != NULL) {
 		printk(KERN_ERR "Error in %s: chip->srb = %p\n",
 			__FUNCTION__, chip->srb);
 		return SCSI_MLQUEUE_HOST_BUSY;
 	}
 
-	
+
 	if (rtsx_chk_stat(chip, RTSX_STAT_DISCONNECT)) {
 		printk(KERN_INFO "Fail command during disconnect\n");
 		srb->result = DID_NO_CONNECT << 16;
-		done(srb);
+		scsi_done(srb);
 		return 0;
 	}
 
-	
-	srb->scsi_done = done;
+
 	chip->srb = srb;
 	up(&(dev->sema));
 
 	return 0;
 }
 
-#if LINUX_VERSION_CODE < KERNEL_VERSION(2, 6, 37)
-static int queuecommand(struct scsi_cmnd *srb,
-			void (*done)(struct scsi_cmnd *))
-{
-	return queuecommand_lck(srb, done);
-}
-#else
 static DEF_SCSI_QCMD(queuecommand)
-#endif
 
 /***********************************************************************
  * Error handling functions
@@ -266,13 +256,7 @@ struct scsi_host_template rtsx_host_template = {
 	
 	.max_sectors =                  240,
 
-	/* merge commands... this seems to help performance, but
-	 * periodically someone should test to see which setting is more
-	 * optimal.
-	 */
-	.use_clustering =		1,
 
-	
 	.emulated =			1,
 
 	
@@ -520,7 +504,7 @@ static int rtsx_control_thread(void * __dev)
 
 		
 		else if (chip->srb->result != DID_ABORT << 16) {
-			chip->srb->scsi_done(chip->srb);
+			scsi_done(chip->srb);
 		} else {
 SkipForAbort:
 			printk(KERN_ERR "scsi command aborted\n");
@@ -556,7 +540,7 @@ SkipForAbort:
 	 * This is important in preemption kernels, which transfer the flow
 	 * of execution immediately upon a complete().
 	 */
-	complete_and_exit(&threads_gone, 0);
+	kthread_complete_and_exit(&threads_gone, 0);
 }
 
 
@@ -602,7 +586,7 @@ static int rtsx_polling_thread(void * __dev)
 	}
 
 	scsi_host_put(host);
-	complete_and_exit(&threads_gone, 0);
+	kthread_complete_and_exit(&threads_gone, 0);
 }
 
 /*
@@ -733,7 +717,7 @@ static void quiesce_and_remove_host(struct rtsx_dev *dev)
 	if (chip->srb) {
 		chip->srb->result = DID_NO_CONNECT << 16;
 		scsi_lock(host);
-		chip->srb->scsi_done(dev->chip->srb);
+		scsi_done(dev->chip->srb);
 		chip->srb = NULL;
 		scsi_unlock(host);
 	}
@@ -777,7 +761,7 @@ static int rtsx_scan_thread(void * __dev)
 	}
 
 	scsi_host_put(rtsx_to_host(dev));
-	complete_and_exit(&threads_gone, 0);
+	kthread_complete_and_exit(&threads_gone, 0);
 }
 
 static void rtsx_init_options(struct rtsx_chip *chip)
@@ -934,7 +918,7 @@ static int rtsx_probe(struct pci_dev *pci, const struct pci_device_id *pci_id)
 
 	printk(KERN_INFO "Resource length: 0x%x\n", (unsigned int)pci_resource_len(pci,0));
 	dev->addr = pci_resource_start(pci, 0);
-	dev->remap_addr = ioremap_nocache(dev->addr, pci_resource_len(pci,0));
+	dev->remap_addr = ioremap(dev->addr, pci_resource_len(pci,0));
 	if (dev->remap_addr == NULL) {
 		printk(KERN_ERR "ioremap error\n");
 		err = -ENXIO;

--- a/rtsx.h
+++ b/rtsx.h
@@ -169,22 +169,24 @@ static inline struct rtsx_dev *host_to_rtsx(struct Scsi_Host *host) {
 
 static inline void get_current_time(u8 *timeval_buf, int buf_len)
 {
-	struct timeval tv;
+	struct timespec64 ts;
+	u32 tv_usec;
 
 	if (!timeval_buf || (buf_len < 8)) {
 		return;
 	}
 
-	do_gettimeofday(&tv);
+	ktime_get_real_ts64(&ts);
+	tv_usec = ts.tv_nsec / NSEC_PER_USEC;
 
-	timeval_buf[0] = (u8)(tv.tv_sec >> 24);
-	timeval_buf[1] = (u8)(tv.tv_sec >> 16);
-	timeval_buf[2] = (u8)(tv.tv_sec >> 8);
-	timeval_buf[3] = (u8)(tv.tv_sec);
-	timeval_buf[4] = (u8)(tv.tv_usec >> 24);
-	timeval_buf[5] = (u8)(tv.tv_usec >> 16);
-	timeval_buf[6] = (u8)(tv.tv_usec >> 8);
-	timeval_buf[7] = (u8)(tv.tv_usec);
+	timeval_buf[0] = (u8)(ts.tv_sec >> 24);
+	timeval_buf[1] = (u8)(ts.tv_sec >> 16);
+	timeval_buf[2] = (u8)(ts.tv_sec >> 8);
+	timeval_buf[3] = (u8)(ts.tv_sec);
+	timeval_buf[4] = (u8)(tv_usec >> 24);
+	timeval_buf[5] = (u8)(tv_usec >> 16);
+	timeval_buf[6] = (u8)(tv_usec >> 8);
+	timeval_buf[7] = (u8)(tv_usec);
 }
 
 /* The scsi_lock() and scsi_unlock() macros protect the sm_state and the

--- a/rtsx_chip.h
+++ b/rtsx_chip.h
@@ -327,8 +327,8 @@ struct sense_data_t {
 #define CHK_BIT(data, idx)	((data) & (1 << (idx)))
 
 #define SG_INT			0x04
-#define SG_END			0x02
-#define SG_VALID		0x01
+#define RTSX_SG_END		0x02
+#define RTSX_SG_VALID		0x01
 
 #define SG_NO_OP		0x00
 #define SG_TRANS_DATA		(0x02 << 4)

--- a/rtsx_scsi.c
+++ b/rtsx_scsi.c
@@ -2728,11 +2728,12 @@ int get_ms_information(struct scsi_cmnd *srb, struct rtsx_chip *chip)
 	}
 	
 	if (dev_info_id == 0x15) {
-		buf_len = data_len = 0x3A;
+		data_len = 0x3A;
 	} else {
-		buf_len = data_len = 0x6A;
+		data_len = 0x6A;
 	}
-	
+	buf_len = data_len + 2;
+
 	buf = (u8 *)kmalloc(buf_len, GFP_KERNEL);
 	if (!buf) {
 		TRACE_RET(chip, TRANSPORT_ERROR);

--- a/rtsx_transport.c
+++ b/rtsx_transport.c
@@ -351,7 +351,7 @@ static inline void rtsx_add_sg_tbl(struct rtsx_chip *chip, u32 addr, u32 len, u8
 	do {
 		if (len > 0x80000) {
 			temp_len = 0x80000;
-			temp_opt = option & (~SG_END);
+			temp_opt = option & (~RTSX_SG_END);
 		} else {
 			temp_len = len;
 			temp_opt = option;
@@ -462,9 +462,9 @@ int rtsx_transfer_sglist_adma_partial(struct rtsx_chip *chip, u8 card, struct sc
 			*index = *index + 1;
 		}
 		if ((i == (sg_cnt - 1)) || !resid) {
-			option = SG_VALID | SG_END | SG_TRANS_DATA;
+			option = RTSX_SG_VALID | RTSX_SG_END | SG_TRANS_DATA;
 		} else {
-			option = SG_VALID | SG_TRANS_DATA;
+			option = RTSX_SG_VALID | SG_TRANS_DATA;
 		}
 
 		rtsx_add_sg_tbl(chip, (u32)addr, (u32)len, option);
@@ -622,9 +622,9 @@ int rtsx_transfer_sglist_adma(struct rtsx_chip *chip, u8 card, struct scatterlis
 			RTSX_DEBUGP(("DMA addr: 0x%x, Len: 0x%x\n", (unsigned int)addr, len));
 
 			if (j == (sg_cnt - 1)) {
-				option = SG_VALID | SG_END | SG_TRANS_DATA;
+				option = RTSX_SG_VALID | RTSX_SG_END | SG_TRANS_DATA;
 			} else {
-				option = SG_VALID | SG_TRANS_DATA;
+				option = RTSX_SG_VALID | SG_TRANS_DATA;
 			}
 
 			rtsx_add_sg_tbl(chip, (u32)addr, (u32)len, option);


### PR DESCRIPTION
This PR modernizes the rtsx driver to be compatible with recent Linux kernel versions by updating deprecated APIs and removing obsolete code patterns.

## Summary
The changes update the driver to use current kernel APIs and remove compatibility code for older kernel versions. This includes modernizing SCSI command handling, thread completion, time functions, and memory mapping calls.

## Key Changes

- **SCSI Command Handling**: Removed the `done` callback parameter from `queuecommand_lck()` and replaced direct callback invocations with `scsi_done()` function calls. Removed kernel version compatibility wrapper for `queuecommand()`.

- **Thread Completion**: Replaced deprecated `complete_and_exit()` calls with `kthread_complete_and_exit()` in three thread functions (`rtsx_control_thread`, `rtsx_polling_thread`, `rtsx_scan_thread`).

- **Time API**: Updated `get_current_time()` to use `ktime_get_real_ts64()` and `struct timespec64` instead of deprecated `do_gettimeofday()` and `struct timeval`.

- **Memory Mapping**: Changed `ioremap_nocache()` to `ioremap()` (which is now the standard and handles caching appropriately).

- **Macro Naming**: Renamed SG (scatter-gather) macros from `SG_END` and `SG_VALID` to `RTSX_SG_END` and `RTSX_SG_VALID` for better namespace clarity.

- **Build System**: Updated Makefile to use `M=$(PWD)` instead of deprecated `SUBDIRS=$(PWD)` parameter for kernel module builds.

- **Code Cleanup**: Removed obsolete `use_clustering` field from `scsi_host_template` and fixed buffer length calculation in `get_ms_information()`.

## Implementation Details

The changes maintain functional equivalence while adopting modern kernel conventions. The removal of the `done` callback parameter aligns with the SCSI subsystem's shift toward using the `scsi_done()` function directly, which is safer and more maintainable.

https://claude.ai/code/session_01JbGWgUu7zrJq4eMskCjtoL